### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#Slate
+# Slate
 *Simple and cool text meme generator*
 
 ![alt tag](http://i.imgur.com/Aj0IWPM.gif)  ![alt tag](http://i.imgur.com/XcpDwZG.gif)
 ![alt tag](http://i.imgur.com/sUAu2Bw.gif)  ![alt tag](http://imgur.com/BqF3fUK.gif)
 
 
-##[See it in Action](http://bitshadow.github.io/Slate)
+## [See it in Action](http://bitshadow.github.io/Slate)
 
 ## Contributing
 Want to add some extra features. Pull requests are welcome :).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
